### PR TITLE
Change MagickWand::read_image_blob to use ref

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -81,7 +81,7 @@ impl MagickWand {
     }
 
     /// Read the image data from the vector of bytes.
-    pub fn read_image_blob(&self, data: Vec<u8>) -> Result<(), &'static str> {
+    pub fn read_image_blob(&self, data: &Vec<u8>) -> Result<(), &'static str> {
         let int_slice = &data[..];
         let size = data.len();
         let result = unsafe {


### PR DESCRIPTION
Breaking change.

The `read_image_blob` function does not need to take ownership of the
image byte array.