### PR TITLE
Remove /usr/local/lib from rustc link search on OSX

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -92,10 +92,6 @@ fn main() {
                 panic!("missing {}, run xcode-select --install", LIBPATH);
             }
             cmd.env("DYLD_LIBRARY_PATH", LIBPATH);
-            // For the sake of easily building and testing on Mac, include
-            // the path to MagickWand. Chances are MagickWand is in
-            // /usr/local/lib, or somewhere else that rustc can find it.
-            println!("cargo:rustc-link-search=native=/usr/local/lib");
         }
         let mut output_arg = String::from("--output");
         output_arg.push('=');


### PR DESCRIPTION
If /usr/local/lib is in the search path, a Homebrew installed libJPEG can end up conflicting with the system libJPEG as such:

```
$ otool -L /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO:
... snip ...
    /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib (compatibility version 1.0.0, current version 1.0.0)
... snip ...
```

```
$ cargo clean && cargo test
... snip ...
Doc-tests magick_rust
dyld: Symbol not found: __cg_jpeg_resync_to_restart
  Referenced from: /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
  Expected in: /usr/local/lib/libJPEG.dylib
 in /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
```

Removing the /usr/local/lib link search path allows successful compilation and testing on my OSX 10.11.6, with jpeg 8d installed into /usr/local/lib via Homebrew. I realize this might be a problem with my setup and not a universal issue, but as Homebrew is so common I thought I'd submit this patch anyways.