### PR TITLE
ImageMagick 7 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,5 @@ build = "build.rs"
 libc = ">=0.2"
 
 [build-dependencies]
-# bindgen 0.26.x results in "already been defined in this module" errors (bug #687)
-bindgen = "0.25.5"
+bindgen = "0.29"
 pkg-config = "0.3.9"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,6 @@ RUN adduser --disabled-password --gecos '' magick-rust
 
 USER magick-rust
 
-ENV USER magick-rust
+ENV USER=magick-rust LD_LIBRARY_PATH=/usr/local/lib
 
 WORKDIR /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1.19.0-stretch
+
+RUN apt-get update \
+ && apt-get -y install curl build-essential clang pkg-config libjpeg-turbo-progs libpng-dev \
+ && rm -rfv /var/lib/apt/lists/*
+
+ENV MAGICK_VERSION 7.0.6-7
+
+RUN curl https://www.imagemagick.org/download/ImageMagick-${MAGICK_VERSION}.tar.gz | tar xz \
+ && cd ImageMagick-${MAGICK_VERSION} \
+ && ./configure --with-magick-plus-plus=no --with-perl=no \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -r ImageMagick-${MAGICK_VERSION}
+
+RUN adduser --disabled-password --gecos '' magick-rust
+
+USER magick-rust
+
+ENV USER magick-rust
+
+WORKDIR /src

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  magick-rust:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/src
+    stdin_open: true
+    tty: true

--- a/src/wand/macros.rs
+++ b/src/wand/macros.rs
@@ -204,13 +204,13 @@ macro_rules! color_set_get {
             pub fn $get(&self) -> f64 {
                 unsafe { ::bindings::$c_get(self.wand) }
             }
-            pub fn $get_quantum(&self) -> u16 {
+            pub fn $get_quantum(&self) -> bindings::Quantum {
                 unsafe { ::bindings::$c_get_quantum(self.wand) }
             }
             pub fn $set(&mut self, v: f64) {
                 unsafe { ::bindings::$c_set(self.wand, v) }
             }
-            pub fn $set_quantum(&mut self, v: u16) {
+            pub fn $set_quantum(&mut self, v: bindings::Quantum) {
                 unsafe { ::bindings::$c_set_quantum(self.wand, v) }
             }
         )*

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -16,7 +16,7 @@
 use std::fmt;
 use std::ptr;
 use std::ffi::{CStr, CString};
-use libc::{c_double, c_void};
+use libc::{c_void};
 
 #[cfg(target_os = "freebsd")]
 use libc::{size_t, ssize_t};
@@ -172,16 +172,12 @@ impl MagickWand {
     }
 
     /// Resize the image to the specified width and height, using the
-    /// specified filter type with the specified blur / sharpness factor.
-    ///
-    /// blur_factor values greater than 1 create blurriness, while values
-    /// less than 1 create sharpness.
+    /// specified filter type.
     pub fn resize_image(&self, width: usize, height: usize,
-                        filter: bindings::FilterTypes, blur_factor: f64) {
+                        filter: bindings::FilterType) {
         unsafe {
             bindings::MagickResizeImage(
-                self.wand, width as size_t, height as size_t,
-                filter, blur_factor as c_double
+                self.wand, width as size_t, height as size_t, filter
             );
         }
     }
@@ -206,7 +202,7 @@ impl MagickWand {
             bindings::MagickResetIterator(self.wand);
             while bindings::MagickNextImage(self.wand) != bindings::MagickBooleanType::MagickFalse {
                 bindings::MagickResizeImage(self.wand, new_width, new_height,
-                                            bindings::FilterTypes::LanczosFilter, 1.0);
+                                            bindings::FilterType::LanczosFilter);
             }
         }
     }
@@ -270,7 +266,7 @@ impl MagickWand {
         let c_format = CString::new(format).unwrap();
         let mut length: size_t = 0;
         let blob = unsafe {
-            bindings::MagickSetImageIndex(self.wand, 0);
+            bindings::MagickSetIteratorIndex(self.wand, 0);
             bindings::MagickSetImageFormat(self.wand, c_format.as_ptr());
             bindings::MagickGetImagesBlob(self.wand, &mut length)
         };
@@ -307,9 +303,8 @@ impl MagickWand {
         get_image_fuzz,                  set_image_fuzz,                  MagickGetImageFuzz,                MagickSetImageFuzz,               f64
         get_image_gamma,                 set_image_gamma,                 MagickGetImageGamma,               MagickSetImageGamma,              f64
         get_image_gravity,               set_image_gravity,               MagickGetImageGravity,             MagickSetImageGravity,            bindings::GravityType
-        get_image_index,                 set_image_index,                 MagickGetImageIndex,               MagickSetImageIndex,              ssize_t
         get_image_interlace_scheme,      set_image_interlace_scheme,      MagickGetImageInterlaceScheme,     MagickSetImageInterlaceScheme,    bindings::InterlaceType
-        get_image_interpolate_method,    set_image_interpolate_method,    MagickGetImageInterpolateMethod,   MagickSetImageInterpolateMethod,  bindings::InterpolatePixelMethod
+        get_image_interpolate_method,    set_image_interpolate_method,    MagickGetImageInterpolateMethod,   MagickSetImageInterpolateMethod,  bindings::PixelInterpolateMethod
         get_image_iterations,            set_image_iterations,            MagickGetImageIterations,          MagickSetImageIterations,         size_t
         get_image_orientation,           set_image_orientation,           MagickGetImageOrientation,         MagickSetImageOrientation,        bindings::OrientationType
         get_image_rendering_intent,      set_image_rendering_intent,      MagickGetImageRenderingIntent,     MagickSetImageRenderingIntent,    bindings::RenderingIntent
@@ -317,7 +312,7 @@ impl MagickWand {
         get_image_type,                  set_image_type,                  MagickGetImageType,                MagickSetImageType,               bindings::ImageType
         get_image_units,                 set_image_units,                 MagickGetImageUnits,               MagickSetImageUnits,              bindings::ResolutionType
         get_interlace_scheme,            set_interlace_scheme,            MagickGetInterlaceScheme,          MagickSetInterlaceScheme,         bindings::InterlaceType
-        get_interpolate_method,          set_interpolate_method,          MagickGetInterpolateMethod,        MagickSetInterpolateMethod,       bindings::InterpolatePixelMethod
+        get_interpolate_method,          set_interpolate_method,          MagickGetInterpolateMethod,        MagickSetInterpolateMethod,       bindings::PixelInterpolateMethod
         get_iterator_index,              set_iterator_index,              MagickGetIteratorIndex,            MagickSetIteratorIndex,           ssize_t
         get_orientation,                 set_orientation,                 MagickGetOrientation,              MagickSetOrientation,             bindings::OrientationType
         get_pointsize,                   set_pointsize,                   MagickGetPointsize,                MagickSetPointsize,               f64

--- a/src/wand/pixel.rs
+++ b/src/wand/pixel.rs
@@ -86,7 +86,7 @@ impl PixelWand {
 
     set_get_unchecked!(
         get_color_count, set_color_count, PixelGetColorCount, PixelSetColorCount,   size_t
-        get_index,       set_index,       PixelGetIndex,      PixelSetIndex,        u16
+        get_index,       set_index,       PixelGetIndex,      PixelSetIndex,        bindings::Quantum
         get_fuzz,        set_fuzz,        PixelGetFuzz,       PixelSetFuzz,         f64
     );
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -24,7 +24,7 @@ use std::io::Read;
 use std::path::Path;
 use std::sync::{Once, ONCE_INIT};
 
-// TODO: nathan does not understand how to expose the FilterTypes without
+// TODO: nathan does not understand how to expose the FilterType without
 //       this ugliness, his Rust skills are sorely lacking
 use magick_rust::bindings;
 
@@ -57,7 +57,7 @@ fn test_resize_image() {
         1 => 1,
         height => height / 2
     };
-    wand.resize_image(halfwidth, halfheight, bindings::FilterTypes::LanczosFilter, 1.0);
+    wand.resize_image(halfwidth, halfheight, bindings::FilterType::LanczosFilter);
     assert_eq!(256, wand.get_image_width());
     assert_eq!(192, wand.get_image_height());
 }


### PR DESCRIPTION
References #11.

I did a quick pass through the code, making it compile and pass the tests with the latest version of ImageMagick (7.0.6-7).

The main changes are:
* bindgen is updated to the latest version. It still has a problem with name collisions, but there's a workaround.
*  Color getters and setters now operate on `Quantum` type, which depends on quantum depth ImageMagick was compiled with: for QD16 it's `f32`, and for QD32 it's `f64`.
* A couple of enums are renamed.
* `MagickGetImageIndex` and `MagickSetImageIndex`are removed (`MagickGetIteratorIndex` and `MagickSetIteratorIndex` seem to replace them now).

I have not implemented any new APIs/methods, following the "those that are needed will be gradually added" philosophy :smile:

On a more serious note, I'm not sure what would be the best way to version the package. ImageMagick 6 is still more widely adopted. Perhaps you could add a separate branch that could be referenced in Cargo deps?
