### PR TITLE
Add color-related getters and transforms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,15 +4,15 @@ RUN apt-get update \
  && apt-get -y install curl build-essential clang pkg-config libjpeg-turbo-progs libpng-dev \
  && rm -rfv /var/lib/apt/lists/*
 
-ENV MAGICK_VERSION 7.0.7-15
+ENV MAX_MAGICK_VERSION 7.0
 
-RUN curl https://www.imagemagick.org/download/ImageMagick-${MAGICK_VERSION}.tar.gz | tar xz \
- && cd ImageMagick-${MAGICK_VERSION} \
+RUN curl https://www.imagemagick.org/download/ImageMagick.tar.gz | tar xz \
+ && cd ImageMagick-${MAX_MAGICK_VERSION}* \
  && ./configure --with-magick-plus-plus=no --with-perl=no \
  && make \
  && make install \
  && cd .. \
- && rm -r ImageMagick-${MAGICK_VERSION}
+ && rm -r ImageMagick-${MAX_MAGICK_VERSION}*
 
 RUN adduser --disabled-password --gecos '' magick-rust
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@ mod conversions;
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 pub use wand::*;
-pub use bindings::MetricType;
+pub use bindings::{MetricType, FilterType, ColorspaceType, DitherMethod};
+pub use conversions::ToMagick;
 
 use libc::size_t;
 #[cfg(not(target_os = "freebsd"))]

--- a/src/wand/macros.rs
+++ b/src/wand/macros.rs
@@ -83,6 +83,16 @@ macro_rules! wand_common {
     }
 }
 
+macro_rules! get {
+    ($($get:ident, $c_get:ident, $typ:ty )*) => {
+        $(
+            pub fn $get(&self) -> $typ {
+                unsafe { ::bindings::$c_get(self.wand) }
+            }
+        )*
+    }
+}
+
 macro_rules! set_get {
     ($($get:ident, $set:ident, $c_get:ident, $c_set:ident, $typ:ty )*) => {
         $(
@@ -225,5 +235,19 @@ macro_rules! color_set_get {
             $( try!(writeln!(f, "{}{:<10}: {:>} quantum: {}", prefix, stringify!($c_get).split_at(8).1, self.$get(), self.$get_quantum())); )*
             Ok(())
         }
+    }
+}
+
+macro_rules! mutations {
+    ($($(#[$attr:meta])* $c_fun:ident => $fun:ident($($arg:ident: $ty:ty),*))*) => {
+        $(
+            $(#[$attr])*
+            pub fn $fun(&self $(, $arg: $ty)*) -> Result<(), &'static str> {
+                match unsafe { bindings::$c_fun(self.wand $(, $arg)*) } {
+                    bindings::MagickBooleanType::MagickTrue => Ok(()),
+                    _ => Err(concat!(stringify!($c_fun), " invocation failed"))
+                }
+            }
+        )*
     }
 }

--- a/src/wand/pixel.rs
+++ b/src/wand/pixel.rs
@@ -23,9 +23,9 @@ use ::size_t;
 
 #[derive(Default, Debug)]
 pub struct HSL {
-    hue: f64,
-    saturation: f64,
-    lightness: f64
+    pub hue: f64,
+    pub saturation: f64,
+    pub lightness: f64
 }
 
 wand_common!(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -16,17 +16,14 @@
 
 extern crate magick_rust;
 
-use magick_rust::{MagickWand, magick_wand_genesis, MetricType};
+use magick_rust::{MagickWand, magick_wand_genesis, MetricType, ColorspaceType, FilterType, DitherMethod};
 
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::sync::{Once, ONCE_INIT};
-
-// TODO: nathan does not understand how to expose the FilterType without
-//       this ugliness, his Rust skills are sorely lacking
-use magick_rust::bindings;
+use magick_rust::ToMagick;
 
 // Used to make sure MagickWand is initialized exactly once. Note that we
 // do not bother shutting down, we simply exit when the tests are done.
@@ -57,7 +54,7 @@ fn test_resize_image() {
         1 => 1,
         height => height / 2
     };
-    wand.resize_image(halfwidth, halfheight, bindings::FilterType::LanczosFilter);
+    wand.resize_image(halfwidth, halfheight, FilterType::LanczosFilter);
     assert_eq!(256, wand.get_image_width());
     assert_eq!(192, wand.get_image_height());
 }
@@ -219,4 +216,47 @@ fn test_page_geometry() {
     assert_eq!((156, 150, 39, 36), wand.get_image_page()); /* width, height, x offset, y offset */
     assert_eq!(80, wand.get_image_width());
     assert_eq!(76, wand.get_image_height());
+}
+
+#[test]
+fn test_transform_image_colorspace() {
+    START.call_once(|| {
+        magick_wand_genesis();
+    });
+    let wand = MagickWand::new();
+    assert!(wand.read_image("tests/data/IMG_5745.JPG").is_ok());
+    assert_eq!(wand.get_image_colorspace(), ColorspaceType::sRGBColorspace);
+
+    let pixel_color = wand.get_image_pixel_color(10, 10).unwrap();
+    assert_ne!(pixel_color.get_hsl().hue, 0.0);
+
+    assert!(wand.transform_image_colorspace(ColorspaceType::GRAYColorspace).is_ok());
+    assert_eq!(wand.get_image_colorspace(), ColorspaceType::GRAYColorspace);
+
+    let pixel_grayscale = wand.get_image_pixel_color(10, 10).unwrap();
+    assert_eq!(pixel_grayscale.get_hsl().hue, 0.0);
+
+    /* The output of `export_image_pixels` should match
+     * `convert -type Grayscale tests/data/IMG_5745.JPG[2x2+0+0] txt:` */
+    assert_eq!(wand.export_image_pixels(0, 0, 2, 2, "I").unwrap(),
+        vec![212, 212, 210, 210])
+}
+
+#[test]
+fn test_color_reduction() {
+    START.call_once(|| {
+        magick_wand_genesis();
+    });
+    let wand = MagickWand::new();
+    assert!(wand.read_image("tests/data/IMG_5745.JPG").is_ok());
+    assert_eq!(38322, wand.get_image_colors());
+
+    assert!(wand.quantize_image(6, ColorspaceType::RGBColorspace, 1,
+                                DitherMethod::UndefinedDitherMethod, false.to_magick()).is_ok());
+    assert_eq!(6, wand.get_image_colors());
+
+    let histogram = wand.get_image_histogram().unwrap();
+    assert_eq!(6, histogram.len());
+    assert_eq!(wand.get_image_width() * wand.get_image_height(),
+               histogram.iter().fold(0, |total_colors, wand| total_colors + wand.get_color_count()));
 }


### PR DESCRIPTION
This PR adds wrappers for `MagickGetImagePixelColor`,  `MagickGetImageHistogram`,  and `MagickExportImagePixels` MagickWand methods, as well as a new `mutations!` macros for defining generic mutation methods, i.e. methods that modify the image(s) in-place and have a return value indicating whether the operation has succeeded or not. I've used it to add  `MagickQuantizeImage`, `MagickTransformImageColorspace`, and `MagickUniqueImageColors`.

These new methods are mostly of use for basic image analysis and fingerprinting.

In addition to that, since _imagemagick.org_ only provides the latest release tarball, I've removed specific version pinning from Dockerfile to avoid build failures after IM updates.