### PR TITLE
Fix exporting pdf->jpeg for multi-page pdf

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -307,8 +307,8 @@ impl MagickWand {
         let c_format = CString::new(format).unwrap();
         let mut length: size_t = 0;
         let blob = unsafe {
-            bindings::MagickSetImageFormat(self.wand, c_format.as_ptr());
             bindings::MagickResetIterator(self.wand);
+            bindings::MagickSetImageFormat(self.wand, c_format.as_ptr());
             bindings::MagickGetImageBlob(self.wand, &mut length)
         };
         let mut bytes = Vec::with_capacity(length as usize);


### PR DESCRIPTION
When trying to convert a multi-page pdf to jpeg i got a pdf file instead of a jpeg file. I figured that the pdf that worked was a one-page pdf and the pdf that did not work was a two-page pdf.

My theory was that the two pages was loaded as to images in the wand and that the format was set on the first page and it exported the second page. And since the second page had the old format, it was exported as a pdf.

Resetting the page iterator before exporting the image fixed the bug, and the multi-page pdf was exported as a jpeg. The image that was exported was just the first page, but it works for my usage.