### PR TITLE
Fix memory management in `string_get!`

### DIFF
--- a/src/wand/macros.rs
+++ b/src/wand/macros.rs
@@ -133,13 +133,14 @@ macro_rules! set_get_unchecked {
 macro_rules! string_get {
     ($get:ident, $c_get:ident) => {
         pub fn $get(&self) -> Result<String, &'static str> {
-            // TODO: memory management
             let ptr = unsafe { ::bindings::$c_get(self.wand) };
             if ptr.is_null() {
                 Err(concat!("null ptr returned by ", stringify!($get)))
             } else {
                 let c_str = unsafe { ::std::ffi::CStr::from_ptr(ptr) };
-                Ok(c_str.to_string_lossy().into_owned())
+                let result: String = c_str.to_string_lossy().into_owned();
+                unsafe { ::bindings::free(ptr as *mut ::libc::c_void) };
+                Ok(result)
             }
         }
     }


### PR DESCRIPTION
Since ImageMagick allocates the result string, and expects the user to free it, the library should do it at some point. And since `.into_owned()` copies it anyway, the result from ImageMagick can be freed immediately.

With this simple fix, memory is no longer leaked each time a string property is read from an image.