### PR TITLE
More MagickWand functions implemented

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -538,6 +538,10 @@ impl MagickWand {
         MagickTransformImageColorspace => transform_image_colorspace(
             colorspace: bindings::ColorspaceType)
 
+        /// Set the image alpha channel mode.
+        MagickSetImageAlphaChannel => set_image_alpha_channel(
+            alpha_channel: bindings::AlphaChannelOption)
+
         /// Reduce the number of colors in the image.
         MagickQuantizeImage => quantize_image(
             number_of_colors: size_t, colorspace: bindings::ColorspaceType,

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -265,6 +265,19 @@ impl MagickWand {
         (width, height, x, y)
     }
 
+    /// Reset the Wand page canvas and position.
+    pub fn reset_image_page(&self, page_geometry: &str) -> Result<(), &'static str> {
+        let c_page_geometry = CString::new(page_geometry).unwrap();
+        let result = unsafe {
+            bindings::MagickResetImagePage(self.wand, c_page_geometry.as_ptr())
+        };
+        if result == bindings::MagickBooleanType::MagickTrue {
+            Ok(())
+        } else {
+            Err("Resetting page geometry failed.")
+        }
+    }
+
     /// Retrieve the named image property value.
     pub fn get_image_property(&self, name: &str) -> Result<String, &'static str> {
         let c_name = CString::new(name).unwrap();

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -108,9 +108,9 @@ impl MagickWand {
     }
 
     /// Read the image data from the vector of bytes.
-    pub fn read_image_blob(&self, data: &Vec<u8>) -> Result<(), &'static str> {
-        let int_slice = &data[..];
-        let size = data.len();
+    pub fn read_image_blob<T: AsRef<[u8]>>(&self, data: T) -> Result<(), &'static str> {
+        let int_slice = data.as_ref();
+        let size = int_slice.len();
         let result = unsafe {
             bindings::MagickReadImageBlob(
                 self.wand, int_slice.as_ptr() as *const c_void, size as size_t)
@@ -118,6 +118,34 @@ impl MagickWand {
         match result {
             bindings::MagickBooleanType::MagickTrue => Ok(()),
             _ => Err("failed to read image")
+        }
+    }
+
+    /// Same as read_image, but reads only the width, height, size and format of an image,
+    /// without reading data.
+    pub fn ping_image(&self, path: &str) -> Result<(), &'static str> {
+        let c_name = CString::new(path).unwrap();
+        let result = unsafe {
+            bindings::MagickPingImage(self.wand, c_name.as_ptr())
+        };
+        match result {
+            bindings::MagickBooleanType::MagickTrue => Ok(()),
+            _ => Err("failed to ping image")
+        }
+    }
+
+    /// Same as read_image, but reads only the width, height, size and format of an image,
+    /// without reading data.
+    pub fn ping_image_blob<T: AsRef<[u8]>>(&self, data: T) -> Result<(), &'static str> {
+        let int_slice = data.as_ref();
+        let size = int_slice.len();
+        let result = unsafe {
+            bindings::MagickPingImageBlob(
+                self.wand, int_slice.as_ptr() as *const c_void, size as size_t)
+        };
+        match result {
+            bindings::MagickBooleanType::MagickTrue => Ok(()),
+            _ => Err("failed to ping image")
         }
     }
 


### PR DESCRIPTION
Added support for `MagickPingImage[Blob]`, `MagickResetImagePage` and `MagickSetImageAlphaChannel`.

One thing changed in existing API is that I made `read_image_blob` accept `AsRef<[u8]>` instead of only `&Vec<u8>`. This should be backwards compatible, and allows passing borrowed slices to this function.