### PR TITLE
feat: level image binding

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -257,8 +257,14 @@ impl MagickWand {
         gamma: f64,
         white_point: f64,
     ) -> Result<(), &'static str> {
-        let result =
-            unsafe { bindings::MagickLevelImage(self.wand, black_point, gamma, white_point) };
+        let result = unsafe {
+            bindings::MagickLevelImage(
+                self.wand,
+                black_point * bindings::QuantumRange,
+                gamma,
+                white_point * bindings::QuantumRange,
+            )
+        };
         match result {
             bindings::MagickBooleanType_MagickTrue => Ok(()),
             _ => Err("failed to set size of wand"),

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -251,6 +251,8 @@ impl MagickWand {
         }
     }
 
+    // Level an image. Black and white points are multiplied with QuantumRange to
+    // decrease dependencies on the end user.
     pub fn level_image(
         &self,
         black_point: f64,

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -251,6 +251,20 @@ impl MagickWand {
         }
     }
 
+    pub fn level_image(
+        &self,
+        black_point: f64,
+        gamma: f64,
+        white_point: f64,
+    ) -> Result<(), &'static str> {
+        let result =
+            unsafe { bindings::MagickLevelImage(self.wand, black_point, gamma, white_point) };
+        match result {
+            bindings::MagickBooleanType_MagickTrue => Ok(()),
+            _ => Err("failed to set size of wand"),
+        }
+    }
+
     /// Extend the image as defined by the geometry, gravity, and wand background color. Set the
     /// (x,y) offset of the geometry to move the original wand relative to the extended wand.
     pub fn extend_image(


### PR DESCRIPTION
MagickLevelImage binding. Multiplying the input with `bindings::QuantumRange` to make it easier to use.