### PR TITLE
Add workaround for QuantumRange not defined error when hdri is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ libc = "0.2.70"
 [build-dependencies]
 bindgen = "0.53.2"
 pkg-config = "0.3.17"
+
+[features]
+
+# Workaround for bindgen bug when ImageMagick is compiled with disable-hdri
+disable-hdri = []


### PR DESCRIPTION
Relates to: https://github.com/nlfiedler/magick-rust/issues/40

Not sure if this is the optimal solution (excluding the fix in bindgen of course which, of course, is) or whether you think adding this kind of workaround is a good idea but I've done it for my own benefit so maybe others would find it useful.

This defines a feature which the user of the library can enable in their project in the case that they're using a build of ImageMagick with --disable-hdri compiled in.

It just uses the same values defined in magick-type.h for each QuantumDepth to the best of my understanding although this may be worth double checking as part of the review. Tests pass with such an ImageMagick build if you run the tests as `cargo test --features=disable-hdri`.

Things to note are: Introduces a `Result` object when accessing the `QuantumRange` and I've not attempted to do anything clever with the types as implied in the magick-type.h file casting it to a `Quantum` which itself is another type and so on... I've just gone with `f64`. I've only gone as far as validating that you can still produce a convincingly sepia toned image (with a value of 0.65) with hdri disabled at Q8 with this change.