### PR TITLE
Required version bump on bindgen.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 libc = "0.2.70"
 
 [build-dependencies]
-bindgen = "0.53.2"
+bindgen = "0.56.0"
 pkg-config = "0.3.17"
 
 [features]


### PR DESCRIPTION
More info: https://github.com/rust-lang/rust-bindgen/pull/1826.