### PR TITLE
Update imagemmagick checks to support 7.1

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const MIN_VERSION: &'static str = "7.0";
-const MAX_VERSION: &'static str = "7.1";
+const MAX_VERSION: &'static str = "7.2";
 
 static HEADER: &'static str = "#include <MagickWand/MagickWand.h>\n";
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
  && apt-get -y install curl build-essential clang pkg-config libjpeg-turbo-progs libpng-dev \
  && rm -rfv /var/lib/apt/lists/*
 
-ENV MAGICK_VERSION 7.0
+ENV MAGICK_VERSION 7.1
 
 RUN curl https://download.imagemagick.org/ImageMagick/download/ImageMagick.tar.gz | tar xz \
  && cd ImageMagick-${MAGICK_VERSION}* \


### PR DESCRIPTION
On Arch Linux, imagemagick is currently at 7.1.0. I tried increasing the
max version and the version used in the Dockerfile to 7.1 and it appears
to compile and tests pass. Version used for local testing:

```
Linux 5.12.12-arch1-1 #1 SMP PREEMPT Fri, 18 Jun 2021 21:59:22 +0000 x86_64 GNU/Linux

Version: ImageMagick 7.1.0-1 Q16 x86_64 2021-06-21 https://imagemagick.org
Copyright: (C) 1999-2021 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules OpenMP(4.5)
Delegates (built-in): bzlib cairo djvu fontconfig freetype heic jbig jng jp2 jpeg lcms lqr ltdl lzma openexr pangocairo png raqm raw rsvg tiff webp wmf x xml zip zlib
```