### PR TITLE
Update ImageMagick version compatibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A somewhat safe Rust interface to the [ImageMagick](http://www.imagemagick.org/)
 ## Dependencies
 
 * Rust stable
-* ImageMagick (version 7.0.x to 7.1.x)
+* ImageMagick (version 7.0.10-36 to 7.1.x)
     - Does _not_ work with ImageMagick 6.x due to backward incompatible changes.
     - [FreeBSD](https://www.freebsd.org): `sudo pkg install ImageMagick7`
     - [Homebrew](http://brew.sh): `brew install imagemagick`


### PR DESCRIPTION
The MagickKmeansImage function appears to have been added in ImageMagick 7.0.10-36.
if you try to build against an earlier version, you'll get a compilation
error about the bindings not having such a function.

For context, I had 7.0.10-34 locally installed on my mac:

```
magick --version
Version: ImageMagick 7.0.10-34 Q16 x86_64 2020-10-09 https://imagemagick.org
Copyright: © 1999-2020 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules OpenMP(3.1)
Delegates (built-in): bzlib freetype gslib heic jng jp2 jpeg lcms lqr ltdl lzma openexr png ps tiff webp xml zlib
```

When building from this project's master branch as of today, I got this compilation error:

```
   Compiling magick_rust v0.15.0 (/Users/dtw/local-dev/magick-rust)
error[E0425]: cannot find function, tuple struct or tuple variant `MagickKmeansImage` in module `bindings`
     --> src/wand/magick.rs:993:9
      |
993   |         MagickKmeansImage => kmeans(number_colors: size_t, max_iterations: size_t, tolerance: f64)
      |         ^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `MagickEmbossImage`
      |
     ::: /Users/dtw/local-dev/magick-rust/target/debug/build/magick_rust-d02543e27ddbd3b9/out/bindings.rs:28115:5
      |
28115 |     pub fn MagickEmbossImage(arg1: *mut MagickWand, arg2: f64, arg3: f64) -> MagickBooleanType;
      |     ------------------------------------------------------------------------------------------- similarly named function `MagickEmbossImage` defined here

For more information about this error, try `rustc --explain E0425`.
```

It appears that `MagickKmeansImage` was relatively recently added in https://github.com/ImageMagick/ImageMagick/commit/8142f8cb0d50ff9276d3c3a0c1360b0e394c13e3.

Based on that commit's page it seems to indicate the earliest version that contains the commit is 7.0.10-36. And if you [compare](https://github.com/ImageMagick/ImageMagick/compare/7.0.10-34...7.0.10-36) the tags for 7.0.10-34 and 7.0.10-36, that commit does indeed show up.

(Once I updated ImageMagick I was able to build without issue)