### PR TITLE
Add binding for MagickStripImage

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -374,6 +374,14 @@ impl MagickWand {
         }
     }
 
+    pub fn strip_image(&self) -> Result<()> {
+        let result = unsafe { bindings::MagickStripImage(self.wand) };
+        match result {
+            bindings::MagickBooleanType_MagickTrue => Ok(()),
+            _ => Err(MagickError("failed to strip image")),
+        }
+    }
+
     pub fn flip_image(&self) -> Result<()> {
         let result = unsafe { bindings::MagickFlipImage(self.wand) };
         match result {


### PR DESCRIPTION
Per the API docs, this should strip all profiles and comments attached
to the image. This can be useful for removing identifying information
from an image (e.g. EXIF tags).