### PR TITLE
FIX:error LNK2019: unresolved external symbol SetMagickResourceLimit …

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -73,6 +73,7 @@ impl MagickWand {
         }
     }
 
+    #[cfg(not(windows))]
     pub fn set_resource_limit(resource: ResourceType, limit: u64) -> Result<()> {
         let result = unsafe {
             bindings::SetMagickResourceLimit(


### PR DESCRIPTION
…referenced in function _ZN11magick_rust4wand6magick10MagickWand18set_resource_limit;

#[cfg(not(windows))] cfgSetMagickResourceLimit;
ImageMagick-7.1.0-Q16-HDRI + Windows\MSVC\14.29.30133
can not link function，I will try find the reason and compare source and .h
This is interim solution