### PR TITLE
Add bindings for MagickDeskewImage

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -875,6 +875,17 @@ impl MagickWand {
         }
     }
 
+    /// Removes skew from the image. Skew is an artifact that
+    /// occurs in scanned images because of the camera being misaligned,
+    /// imperfections in the scanning or surface, or simply because the paper was
+    /// not placed completely flat when scanned
+    pub fn deskew_image(&mut self, threshold: f64) -> Result<()> {
+        match unsafe { bindings::MagickDeskewImage(self.wand, threshold) } {
+            bindings::MagickBooleanType_MagickTrue => Ok(()),
+            _ => Err(MagickError("unable to deskew image")),
+        }
+    }
+
     /// Set image channel mask
     pub fn set_image_channel_mask(
         &mut self,


### PR DESCRIPTION
Add support for [MagickDeskewImage](https://imagemagick.org/api/magick-image.php#MagickDeskewImage) to address #91 

In the [C implementation of MagickDeskewImage](https://github.com/ImageMagick/ImageMagick/blob/0c5784d96b39e3ea78105b595dab1342bb963799/MagickWand/magick-image.c#L2764-L2808) the function accepts a C float for the threshold parameter. I typed that a f64 in Rust but please let me know if you have any explicit guidance on how to convert C types.

I followed the pattern from #89 so there's no explicit unit test for this new functionality but I verified it locally with a small test project:

```rust
use magick_rust::{magick_wand_genesis, MagickWand};
use std::sync::Once;

static START: Once = Once::new();

fn process_image(path: &str) {
    let mut wand = MagickWand::new();
    wand.read_image(path).unwrap();
    wand.deskew_image(1.0).unwrap();
    wand.write_image(&format!("new-{}", path)).unwrap();
}

fn main() {
    START.call_once(|| {
        magick_wand_genesis();
    });

    let mut args = std::env::args();

    // skip binary name
    args.next();

    // image file to strip
    let path = args.next().unwrap();

    println!("path: {}", path);

    process_image(&path);
}
```