### PR TITLE
Upgrade dependency `bindgen` (0.59 -> 0.60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file follows the convention described at
 ## Unreleased
 ### Added
 - walterbm: Add support for image deskew.
+- DCjanus: Upgrade dependency `bindgen` (0.59 -> 0.60)
 
 ## [0.16.0] - 2022-04-09
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = "0.60"
 pkg-config = "0.3"
 
 [features]


### PR DESCRIPTION
I was using clap 3.x, and I noticed that bindgen 0.59 using clap 2.x, let's upgrade it.