### PR TITLE
Add bindings for `DrawRectangle` and `MagickBrightnessContrastImage` methods

### DIFF
--- a/src/wand/drawing.rs
+++ b/src/wand/drawing.rs
@@ -51,6 +51,24 @@ impl DrawingWand {
         }
     }
 
+    pub fn draw_rectangle(
+        &mut self,
+        upper_left_x: f64,
+        upper_left_y: f64,
+        lower_right_x: f64,
+        lower_right_y: f64,
+    ) {
+        unsafe {
+            bindings::DrawRectangle(
+                self.wand,
+                upper_left_x,
+                upper_left_y,
+                lower_right_x,
+                lower_right_y,
+            );
+        }
+    }
+
     string_set_get!(
         get_font,                   set_font,                     DrawGetFont,                  DrawSetFont
         get_font_family,            set_font_family,              DrawGetFontFamily,            DrawSetFontFamily

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -986,10 +986,10 @@ impl MagickWand {
         MagickTransformImageColorspace => transform_image_colorspace(
             colorspace: bindings::ColorspaceType)
 
-        // Sets the image to the specified alpha level.
+        /// Sets the image to the specified alpha level.
         MagickSetImageAlpha => set_image_alpha(alpha: f64)
 
-        // Control the brightness, saturation, and hue of an image
+        /// Control the brightness, saturation, and hue of an image
         MagickModulateImage => modulate_image(brightness: f64, saturation: f64, hue: f64)
 
         /// Control the brightness and contrast

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -992,6 +992,9 @@ impl MagickWand {
         // Control the brightness, saturation, and hue of an image
         MagickModulateImage => modulate_image(brightness: f64, saturation: f64, hue: f64)
 
+        /// Control the brightness and contrast
+        MagickBrightnessContrastImage => brightness_contrast_image(brightness: f64, contrast: f64)
+
         /// Set the image alpha channel mode.
         MagickSetImageAlphaChannel => set_image_alpha_channel(
             alpha_channel: bindings::AlphaChannelOption)


### PR DESCRIPTION
Just like the title says, I've added bindings for the `DrawRectangle` method and `MagickBrightnessContrastImage`.

In another commit, I changed 2 normal comments into docstrings, so that LSP can show them when they are hovered over.
It seemed like too small of a change to deserve its own PR, so thought it could be merged with this one.