### PR TITLE
add optional argment to cargo test

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pretty simple for now.
 
 ```shell
 $ cargo build
-$ cargo test
+$ cargo test --lib
 ```
 
 Optionally you can set some environment variables before building:


### PR DESCRIPTION
When I tried to test build result by "cargo test", it failed.

It seems to add "--lib" argument for treat this error

Please check my pull request for detail

*My environment (WSL2 in Windows11)*
- OS
  - NAME="Ubuntu"
  - VERSION="20.04.5 LTS (Focal Fossa)"
  - ID=ubuntu
  - ID_LIKE=debian
  - PRETTY_NAME="Ubuntu 20.04.5 LTS"
  - VERSION_ID="20.04"
- Rust
  - cargo 1.66.1 (ad779e08b 2023-01-10)