### PR TITLE
Add map argument to MagickWand::import_image_pixels

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -938,7 +938,7 @@ impl MagickWand {
         }
     }
 
-    /// Accepts pixel datand stores it in the image at the location you specify.
+    /// Accepts pixel data and stores it in the image at the location you specify.
     /// See <https://imagemagick.org/api/magick-image.php#MagickImportImagePixels> for more information.
     pub fn import_image_pixels(
         &mut self,
@@ -946,9 +946,10 @@ impl MagickWand {
         y: isize,
         columns: usize,
         rows: usize,
-        pixels: &Vec<u8>,
+        pixels: &[u8],
+        map: &str,
     ) -> Result<()> {
-        let pixel_map = CString::new("RGBA").unwrap();
+        let pixel_map = CString::new(map).unwrap();
         match unsafe {
             bindings::MagickImportImagePixels(
                 self.wand,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -396,3 +396,23 @@ fn test_resource_limits() {
     let wand = MagickWand::new();
     assert!(wand.read_image("tests/data/rust.png").is_ok());
 }
+
+#[test]
+fn test_import_export_pixels_roundtrip() {
+    START.call_once(|| {
+        magick_wand_genesis();
+    });
+    let w = 2;
+    let h = 2;
+    let map = "RGB";
+    let pixels = [0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255];
+    let mut wand = MagickWand::new();
+    wand.new_image(4, 4, &PixelWand::new()).unwrap();
+    assert!(wand.import_image_pixels(0, 0, w, h, &pixels, map).is_ok());
+    let exported_pixels = wand.export_image_pixels(0, 0, w, h, map).unwrap();
+    assert_eq!(exported_pixels.len(), pixels.len());
+    assert!(exported_pixels
+        .iter()
+        .zip(pixels.iter())
+        .all(|(a, b)| a == b));
+}


### PR DESCRIPTION
... and update the pixels argument to a slice.

Now, callers can specify the pixel layout and call this function without an owned Vec.