### PR TITLE
Deploy docs to github pages (without storing in repository).

### DIFF
--- a/.github/static-files/index.html
+++ b/.github/static-files/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta http-equiv="Refresh" content="0; url='magick_rust/index.html'" />
+  </head>
+  <body>
+    <p>Please <a href="magick_rust/index.html">click here</a> if you are not automatically redirected.</p>
+  </body>
+</html>

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,55 @@
+name: Build and deploy docs
+
+on:
+  push:
+    branches:
+      - master
+    workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: deps
+        run: |
+          # sudo apt update && sudo apt install -y libmagickwand-dev
+          curl https://imagemagick.org/archive/ImageMagick.tar.gz | tar xz
+          cd ImageMagick-7.1*
+          ./configure --with-magick-plus-plus=no --with-perl=no 
+          make -j
+          sudo make install
+      - uses: Swatinem/rust-cache@v2
+      - name: build docs
+        run: |
+          cargo doc --no-deps
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./target/doc
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+
+
+

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: build docs
         run: |
           cargo doc --no-deps
+          cp .github/static-files/index.html target/doc/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
@@ -43,8 +44,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A somewhat safe Rust interface to the [ImageMagick](http://www.imagemagick.org/) system, in particular, the MagickWand library. Many of the functions in the MagickWand API are still missing, but over time more will be added. Pull requests are welcome.
 
+## Documentation
+
+Documentation for upstream is hosted on [github pages](https://nlfiedler.github.io/magick-rust).  To build locally run `cargo doc`.
+
 ## Dependencies
 
 * Rust stable


### PR DESCRIPTION
Github pages now allows you to deploy straight from an action without committing anything to a repo.

This PR adds a workflow which builds the docs for master and then deploys them.  It would be possible to checkout all tags and build them all, but a menu would be needed.

The intention is not to substitute for just running `cargo doc` locally, but to provide something visible online for people (like me!) discovering the library and wanting to glance at the docs before doing anything with it.

Before merging you will need to enable pages in the repository settings, and set the source to 'build with action (beta)'.

Closes #31. (maybe)