### PR TITLE
Add support for image coalesce

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -262,6 +262,18 @@ impl MagickWand {
         }
     }
 
+    /// Rebuilds image sequence with each frame size the same as first frame, and composites each frame atop of previous.
+    /// Only affects GIF, and other formats with multiple pages/layers.
+    pub fn coalesce(&mut self) -> Result<()> {
+        let result = unsafe { bindings::MagickCoalesceImages(self.wand) };
+        if result.is_null() {
+            Err(MagickError("failed to coalesce images"))
+        } else {
+            self.wand = result;
+            Ok(())
+        }
+    }
+
     // Replaces colors in the image from a color lookup table.
     pub fn clut_image(
         &self,


### PR DESCRIPTION
Add support for the ImageMagick coalesce operation ([`MagickCoalesceImages`](https://imagemagick.org/api/magick-image.php#MagickCoalesceImages)). Coalesce is useful when converting animated images (e.g. GIF to WebP) to remove GIF optimizations and reproduce the full image at each point in the animation sequence. This creates an image sequence that is much easier to modify in other formats.

I discovered the need for coalesce because it turns out that [before ImageMagick 7.1.x coalesce was applied automatically when converting an animated GIF to WebP](https://github.com/ImageMagick/ImageMagick/issues/6041#issuecomment-1422293737). That is no longer the case so an explicit call to `coalesce` is required to ensure operations on animated GIFs don't create frame artifacts like "dropouts".  

`MagickCoalesceImages` does not modify the `MagickWand` instance that is passed in as an argument so to make the mutation work as expected this new `coalesce` method replaces the value of `self.wand` with the result from `MagickCoalesceImages`

