### PR TITLE
Add compose_images_gravity

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -262,6 +262,27 @@ impl MagickWand {
         }
     }
 
+    /// Compose another image onto self with gravity using composition_operator
+    pub fn compose_images_gravity(
+        &self,
+        reference: &MagickWand,
+        composition_operator: bindings::CompositeOperator,
+        gravity_type: bindings::GravityType,
+    ) -> Result<()> {
+        let result = unsafe {
+            bindings::MagickCompositeImageGravity(
+                self.wand,
+                reference.wand,
+                composition_operator,
+                gravity_type,
+            )
+        };
+        match result {
+            bindings::MagickBooleanType_MagickTrue => Ok(()),
+            _ => Err(MagickError("failed to compose images")),
+        }
+    }
+
     /// Rebuilds image sequence with each frame size the same as first frame, and composites each frame atop of previous.
     /// Only affects GIF, and other formats with multiple pages/layers.
     pub fn coalesce(&mut self) -> Result<()> {


### PR DESCRIPTION
Hello! This PR adds the compose_images_gravity method which calls the MagickCompositeImageGravity function. It'd be nice to be able to use gravity when using the composite function instead of providing coordinates.

Here is a sample program:
```rust
use std::sync::Once;

use magick_rust::{
    bindings::{
        CompositeOperator_UndefinedCompositeOp, GravityType_CenterGravity, GravityType_EastGravity,
        GravityType_NorthEastGravity, GravityType_NorthGravity, GravityType_NorthWestGravity,
        GravityType_SouthEastGravity, GravityType_SouthGravity, GravityType_SouthWestGravity,
        GravityType_UndefinedGravity, GravityType_WestGravity,
    },
    magick_wand_genesis, MagickWand,
};

static START: Once = Once::new();

fn main() {
    START.call_once(|| {
        magick_wand_genesis();
    });

    let background = MagickWand::new();
    background.read_image("src/background.png").unwrap();

    let foreground = MagickWand::new();
    foreground.read_image("src/foreground.png").unwrap();

    for g in 0..9 {
        let composite = background.clone();
        composite
            .compose_images_gravity(&foreground, CompositeOperator_UndefinedCompositeOp, g)
            .unwrap();
        let name = match g {
            GravityType_CenterGravity => "GravityType_CenterGravity.png",
            GravityType_EastGravity => "GravityType_EastGravity.png",
            GravityType_NorthEastGravity => "GravityType_NorthEastGravity.png",
            GravityType_NorthGravity => "GravityType_NorthGravity.png",
            GravityType_NorthWestGravity => "GravityType_NorthWestGravity.png",
            GravityType_SouthEastGravity => "GravityType_SouthEastGravity.png",
            GravityType_SouthGravity => "GravityType_SouthGravity.png",
            GravityType_SouthWestGravity => "GravityType_SouthWestGravity.png",
            GravityType_UndefinedGravity => "GravityType_UndefinedGravity.png",
            GravityType_WestGravity => "GravityType_WestGravity.png",
            _ => "na.png",
        };
        composite.write_image(name).unwrap();
    }
}
```

Here is an album with compositions https://imgur.com/a/2fXgrLU