### PR TITLE
Support building with ImageMagick from MSYS2

### DIFF
--- a/.github/workflows/test-msys2.yaml
+++ b/.github/workflows/test-msys2.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_MAGICK_LIBS: "MagickCore-7.Q16HDRI;MagickWand-7.Q16HDRI"
+  IMAGE_MAGICK_LIBS: "libMagickCore-7.Q16HDRI.dll.a;libMagickWand-7.Q16HDRI.dll.a"
 
 jobs:
   build:
@@ -16,21 +16,10 @@ jobs:
         run: |
           export PATH="/mingw64/bin:$PATH"
           pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-pkg-config
-          cd /mingw64/lib
-          mv libMagickCore-7.Q16HDRI.dll.a MagickCore-7.Q16HDRI.lib
-          mv libMagickWand-7.Q16HDRI.dll.a MagickWand-7.Q16HDRI.lib
-
-      - name: Set environment variables
-        shell: C:\msys64\usr\bin\bash.exe --login '{0}'
-        run: |
-          export PATH="/mingw64/bin:$PATH"
-          echo "BINDGEN_EXTRA_CLANG_ARGS=$(MagickCore-config --cppflags)" >> $GITHUB_ENV
-
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - name: Test
         run: |
-          echo $env:BINDGEN_EXTRA_CLANG_ARGS
-          $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
-          cargo test test_new_drop -- --nocapture
+          $env:PATH = "C:\msys64\usr\bin;C:\msys64\mingw64\bin;$env:PATH"
+          cargo test -- --skip test_set_background_color

--- a/.github/workflows/test-msys2.yaml
+++ b/.github/workflows/test-msys2.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Test
         run: |
           $env:PATH = "C:\msys64\usr\bin;C:\msys64\mingw64\bin;$env:PATH"
-          cargo test -- --skip test_set_background_color
+          cargo test -- --skip background --skip negate_image

--- a/.github/workflows/test-msys2.yaml
+++ b/.github/workflows/test-msys2.yaml
@@ -1,0 +1,36 @@
+name: Run tests on Windows
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_MAGICK_LIBS: "MagickCore-7.Q16HDRI;MagickWand-7.Q16HDRI"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        shell: C:\msys64\usr\bin\bash.exe --login '{0}'
+        run: |
+          export PATH="/mingw64/bin:$PATH"
+          pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-pkg-config
+          cd /mingw64/lib
+          mv libMagickCore-7.Q16HDRI.dll.a MagickCore-7.Q16HDRI.lib
+          mv libMagickWand-7.Q16HDRI.dll.a MagickWand-7.Q16HDRI.lib
+
+      - name: Set environment variables
+        shell: C:\msys64\usr\bin\bash.exe --login '{0}'
+        run: |
+          export PATH="/mingw64/bin:$PATH"
+          echo "BINDGEN_EXTRA_CLANG_ARGS=$(MagickCore-config --cppflags)" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Test
+        run: |
+          echo $env:BINDGEN_EXTRA_CLANG_ARGS
+          $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
+          cargo test test_new_drop -- --nocapture

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,19 @@ use std::process::Command;
 const MIN_VERSION: &str = "7.0";
 const MAX_VERSION: &str = "7.2";
 
+#[cfg(windows)]
+static HEADER: &str = r#"
+#if !defined(ssize_t) && !defined(__MINGW32__)
+#if defined(_WIN64)
+typedef __int64 ssize_t;
+#else
+typedef long ssize_t;
+#endif
+#endif
+
+#include <MagickWand/MagickWand.h>
+"#;
+#[cfg(not(windows))]
 static HEADER: &str = "#include <MagickWand/MagickWand.h>\n";
 
 //on windows path env always contain : like c:
@@ -35,7 +48,18 @@ pub const PATH_SEPARATOR: &str = match cfg!(target_os = "windows") {
 };
 
 fn main() {
-    let check_cppflags = Command::new("MagickCore-config").arg("--cppflags").output();
+    let check_cppflags = if cfg!(target_os = "windows") {
+        // Resolve bash from directories listed in the PATH environment variable in the
+        // order they appear.
+        Command::new("cmd")
+            .arg("/C")
+            .arg("bash")
+            .arg("MagickCore-config")
+            .arg("--cppflags")
+            .output()
+    } else {
+        Command::new("MagickCore-config").arg("--cppflags").output()
+    };
     if let Ok(ok_cppflags) = check_cppflags {
         let cppflags = ok_cppflags.stdout;
         let cppflags = String::from_utf8(cppflags).unwrap();

--- a/build.rs
+++ b/build.rs
@@ -260,6 +260,11 @@ fn determine_mode<T: AsRef<str>>(libdirs: &Vec<PathBuf>, libs: &[T]) -> &'static
         (true, false) => return "static",
         (false, true) => return "dylib",
         (false, false) => {
+            let can_static_verbatim = libs.iter().all(|l| files.contains(l.as_ref()));
+            if can_static_verbatim {
+                return "static:+verbatim";
+            }
+
             panic!(
                 "ImageMagick libdirs at `{:?}` do not contain the required files \
                  to either statically or dynamically link ImageMagick",


### PR DESCRIPTION
Linking against libraries from MSYS2 is useful as it provides unified configuration on Windows as Unix-like systems. By defining proper `IMAGE_MAGICK_*` env vars it's almost possible with magick-rust, and we just need to address the following issues:

1. Unlike in VisualMagick, `magick-baseconfig.h` generated on MSYS2 doesn't have `MAGICKCORE_HDRI_ENABLE` and `MAGICKCORE_QUANTUM_DEPTH` defined. So we should make sure `MagickCore-config` can be called using MSYS2's shell during compilation. One easy way is launch `cmd /C bash MagickCore-config --cppflags` to work around Rust's [default behavior](https://github.com/rust-lang/rust/pull/87704).
2. `ssize_t` is not defined in Visual C++.
3. MSYS2 uses unconventional extension `.dll.a` for import libs. Without them it will produce errors like [this](https://github.com/nlfiedler/magick-rust/issues/77#issuecomment-1132515226).

This PR also adds a workflow that runs successfully with the preinstalled MSYS2 from the Windows runner image.