### PR TITLE
Remove Windows-specific invocation of MagickCore-config

### DIFF
--- a/.github/workflows/test-msys2.yaml
+++ b/.github/workflows/test-msys2.yaml
@@ -1,4 +1,4 @@
-name: Run tests on Windows
+name: Run tests on Windows (MSYS2)
 
 on:
   workflow_dispatch:
@@ -14,12 +14,12 @@ jobs:
       - name: Install dependencies
         shell: C:\msys64\usr\bin\bash.exe --login '{0}'
         run: |
-          export PATH="/mingw64/bin:$PATH"
-          pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-pkg-config
+          export PATH="/ucrt64/bin:$PATH"
+          pacman --noconfirm -S mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - name: Test
         run: |
-          $env:PATH = "C:\msys64\usr\bin;C:\msys64\mingw64\bin;$env:PATH"
-          cargo test -- --skip background --skip negate_image
+          $env:PATH = "C:\msys64\usr\bin;C:\msys64\ucrt64\bin;$env:PATH"
+          cargo test -- --skip test_set_background_color

--- a/build.rs
+++ b/build.rs
@@ -113,25 +113,14 @@ impl bindgen::callbacks::ParseCallbacks for RemoveEnumVariantSuffixes {
 }
 
 fn main() {
-    let check_cppflags = if cfg!(all(target_os = "windows", not(target_env = "msvc"))) {
-        // Resolve bash from directories listed in the PATH environment variable in the
-        // order they appear.
-        Command::new("cmd")
-            .arg("/C")
-            .arg("bash")
-            .arg("MagickCore-config")
-            .arg("--cppflags")
-            .output()
-    } else {
-        Command::new("MagickCore-config")
-            .arg("--cppflags")
-            .output()
-            .or_else(|_| {
-                Command::new("pkg-config")
-                    .args(["--cflags", "MagickCore"])
-                    .output()
-            })
-    };
+    let check_cppflags = Command::new("MagickCore-config")
+        .arg("--cppflags")
+        .output()
+        .or_else(|_| {
+            Command::new("pkg-config")
+                .args(["--cflags", "MagickCore"])
+                .output()
+        });
     if let Ok(ok_cppflags) = check_cppflags {
         let cppflags = ok_cppflags.stdout;
         let cppflags = String::from_utf8(cppflags).unwrap();

--- a/src/wand/pixel.rs
+++ b/src/wand/pixel.rs
@@ -93,7 +93,7 @@ impl PixelWand {
 
     set_get_unchecked!(
         get_color_count, set_color_count, PixelGetColorCount, PixelSetColorCount,   usize
-        get_index,       set_index,       PixelGetIndex,      PixelSetIndex,        f32
+        get_index,       set_index,       PixelGetIndex,      PixelSetIndex,        bindings::Quantum
         get_fuzz,        set_fuzz,        PixelGetFuzz,       PixelSetFuzz,         f64
     );
 


### PR DESCRIPTION
- Removes Windows-specific invocation of `MagickCore-config` in build script.

    This was added in #114 to support building on MSYS2, and modified in #126 to address some issues of native [ImageMagick-Windows](https://github.com/ImageMagick/ImageMagick-Windows) build. However, the `not(target_env = "msvc")` flag does not cover a scenario where ImageMagick and its dependencies are built and managed on MSYS2 while your own application is built with MSVC. Fortunately, with #132 it is no longer needed, and on MSYS2 it just takes the fallback path.
- Uses ucrt64 instead of mingw64 in `test-msys2.yaml` workflow, as ucrt64 has fewer compatibility issues.
- Fixes #137.