### PR TITLE
Some simplifying changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 rust-bindgen
 target
 .idea
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ pkg-config = "0.3"
 default = ["disable-hdri"]
 # Workaround for bindgen bug when ImageMagick is compiled with disable-hdri
 disable-hdri = []
+
+[lints.clippy]
+missing_safety_doc =  { level = "allow" }

--- a/README.md
+++ b/README.md
@@ -63,4 +63,6 @@ docker compose run magick-rust
 cargo clean
 cargo build
 cargo test
+exit
+docker compose down
 ```

--- a/build.rs
+++ b/build.rs
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-extern crate bindgen;
-extern crate pkg_config;
 
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -52,12 +50,8 @@ struct IgnoreMacros {
     macros_to_ignore: HashSet<String>,
 }
 
-impl IgnoreMacros {
-    fn from_iter<S, I>(macro_names: I) -> Self
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
+impl<S: Into<String>> FromIterator<S> for IgnoreMacros {
+    fn from_iter<T: IntoIterator<Item=S>>(macro_names: T) -> Self {
         let mut macros_to_ignore = HashSet::new();
         for macro_name in macro_names {
             macros_to_ignore.insert(macro_name.into());
@@ -81,17 +75,12 @@ struct RemoveEnumVariantSuffixes {
     names_to_suffix: HashMap<String, String>,
 }
 
-impl RemoveEnumVariantSuffixes {
-    fn from_iter<S, I>(enum_suffix_pairs: I) -> Self
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = (S, S)>,
-    {
+impl<S: Into<String>> FromIterator<(S, S)> for RemoveEnumVariantSuffixes {
+    fn from_iter<T: IntoIterator<Item=(S, S)>>(enum_suffix_pairs: T) -> Self {
         let mut names_to_suffix = HashMap::new();
         for (enum_name, variant_suffix) in enum_suffix_pairs {
             names_to_suffix.insert(enum_name.into(), variant_suffix.into());
         }
-
         Self { names_to_suffix }
     }
 }
@@ -271,7 +260,8 @@ fn main() {
         let mut builder = bindgen::Builder::default()
             .emit_builtins()
             .ctypes_prefix("libc")
-            .raw_line("extern crate libc;")
+            .raw_line("#![allow(clippy::all)]")
+            .raw_line("use libc;")
             .header(gen_h_path.to_str().unwrap())
             .size_t_is_usize(true)
             .parse_callbacks(Box::new(ignored_macros))

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   magick-rust:
     build:

--- a/examples/add-border.rs
+++ b/examples/add-border.rs
@@ -1,4 +1,3 @@
-extern crate magick_rust;
 use magick_rust::{CompositeOperator, MagickError, MagickWand, PixelWand, magick_wand_genesis};
 use std::fs;
 use std::sync::Once;

--- a/examples/thumbnail-cat.rs
+++ b/examples/thumbnail-cat.rs
@@ -1,7 +1,6 @@
 //
 // Copyright (c) 2024 Nathan Fiedler
 //
-extern crate magick_rust;
 use magick_rust::{MagickError, MagickWand, magick_wand_genesis};
 use std::fs;
 use std::sync::Once;

--- a/src/types/kernel.rs
+++ b/src/types/kernel.rs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::bindings;
+use crate::{GeometryInfo, KernelInfoType, bindings};
 use crate::{MagickError, Result};
 use std::ffi::CString;
 
@@ -75,8 +75,8 @@ pub struct KernelBuilder {
     center: Option<(usize, usize)>,
     values: Option<Vec<f64>>,
 
-    info_type: Option<crate::KernelInfoType>,
-    geom_info: Option<crate::GeometryInfo>,
+    info_type: Option<KernelInfoType>,
+    geom_info: Option<GeometryInfo>,
 }
 
 impl KernelBuilder {
@@ -164,11 +164,7 @@ impl KernelBuilder {
 
         // Create kernel info
         let kernel_info = unsafe {
-            bindings::AcquireKernelBuiltIn(
-                info_type.into(),
-                geom_info.inner(),
-                std::ptr::null_mut(),
-            )
+            bindings::AcquireKernelBuiltIn(info_type, geom_info.inner(), std::ptr::null_mut())
         };
 
         if kernel_info.is_null() {

--- a/src/wand/macros.rs
+++ b/src/wand/macros.rs
@@ -22,6 +22,12 @@ macro_rules! wand_common {
             pub wand: *mut crate::bindings::$wand,
         }
 
+        impl Default for $wand {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
         impl $wand {
             pub fn new() -> Self {
                 $wand {

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -220,14 +220,14 @@ impl MagickWand {
     /// using the given composition that has been assigned to each individual image.
     ///
     /// * `method`: the method of selecting the size of the initial canvas.
-    ///     MergeLayer: Merge all layers onto a canvas just large enough to hold all the actual
-    ///     images. The virtual canvas of the first image is preserved but otherwise ignored.
+    ///   MergeLayer: Merge all layers onto a canvas just large enough to hold all the actual
+    ///   images. The virtual canvas of the first image is preserved but otherwise ignored.
     ///
     ///     FlattenLayer: Use the virtual canvas size of first image. Images which fall outside
-    ///     this canvas is clipped. This can be used to 'fill out' a given virtual canvas.
+    ///   this canvas is clipped. This can be used to 'fill out' a given virtual canvas.
     ///
     ///     MosaicLayer: Start with the virtual canvas of the first image, enlarging left and right
-    ///     edges to contain all images. Images with negative offsets will be clipped.
+    ///   edges to contain all images. Images with negative offsets will be clipped.
     pub fn merge_image_layers(&self, method: LayerMethod) -> Result<MagickWand> {
         let result = unsafe { bindings::MagickMergeImageLayers(self.wand, method) };
         if result.is_null() {

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,0 +1,56 @@
+use std::fs::File;
+use std::path::PathBuf;
+use magick_rust::MagickWand;
+
+pub struct Fixture {
+    filename: &'static str,
+    width: usize,
+    height: usize,
+}
+
+impl Fixture {
+    const fn new(filename: &'static str, width: usize, height: usize) -> Self {
+        Self {
+            filename,
+            width,
+            height,
+        }
+    }
+
+    fn path(&self) -> PathBuf {
+        PathBuf::from("tests/fixtures").join(self.filename)
+    }
+
+    pub fn file(&self) -> File {
+        File::open(self.path())
+            .unwrap_or_else(|e| panic!("failed to open file {:?}: {}", self.path(), e))
+    }
+
+    fn path_to_string(&self) -> String {
+        self.path()
+            .to_str()
+            .expect("Failed to form path")
+            .to_owned()
+    }
+
+    pub fn read_image(&self, wand: &MagickWand) {
+        wand.read_image(&self.path_to_string())
+            .unwrap_or_else(|e| panic!("Failed to read image {}: {}", self.filename, e));
+    }
+
+    pub fn assert_width(&self, wand: &MagickWand) {
+        assert_eq!(self.width, wand.get_image_width(), "width mismatch in image {}", self.filename);
+    }
+
+    pub fn assert_height(&self, wand: &MagickWand) {
+        assert_eq!(self.height, wand.get_image_height(), "height mismatch in image {}", self.filename);
+    }
+}
+
+pub const IMG_5745_JPG: Fixture = Fixture::new("IMG_5745.JPG", 512, 384);
+pub const IMG_5745_ROTL_JPG: Fixture = Fixture::new("IMG_5745_rotl.JPG", 384, 512);
+pub const RUST_PNG: Fixture = Fixture::new("rust.png", 240, 240);
+pub const RUST_GIF: Fixture = Fixture::new("rust.gif", 80, 76);
+pub const RUST_SVG: Fixture = Fixture::new("rust.svg", 144, 144);
+
+pub const ALL_FIXTURES: [Fixture; 5] = [IMG_5745_JPG, IMG_5745_ROTL_JPG, RUST_PNG, RUST_GIF, RUST_SVG];


### PR DESCRIPTION
Tested on MacOS and in the Docker container.

### Library changes

- Various small simplifications & a few `rust-fmt` changes.
- Some reasonable allows to make `cargo clippy` find no problems now:
  - Added an allow in the `toml` for the Clippy lint about safety documentation.
  - Added a raw line to the generated FFI code to have Clippy ignore all its contents.
- Changed functions named `from_iter` to be implementations of `FromIterator`
- Changed `extern crate` to plain `use` as they are no longer needed since the upgrade to `2024 edition`
- Added a `Default` impl to the `wand_common` macro as it has a parameterless `new()`

### Testing changes

New structs and constants to simplify the tests a bit, and remove some of the repetative values:

- Created `fixtures.rs` to contain:
  - Metadata on the images -- filename, width, height
  - Functions to replace common assertions
  - Utility functions e.g. `fn file` to open the image as a file.

### Other changes

- Updated the Docker compose file (version is obsolete) & the README section on docker (I forgot about doing docker compose down 🤦)
- Added a gitignore for MacOS image attribute files

### Bindgen info

To spread the knowledge of two things I noticed -- the first will be resolved soon:

**128-bit values over FFI**

The compiler warns about 128-bit values being passed over FFI as they have unstable representation. However this will be fixed by Rust 1.89 on the 7th August.

**Pointer to functions comparisons**

Clippy warned about using comparisons of pointers to functions (`Equals`, `PartialEq` derived).

It seems that pointers to functions have unreliable equality results, depending on complier optimisations. They can point to the same function and be false, or be equal and apply to two different functions.

An example of where this could be problematic is with `ImageInfo` due to its `progress_monitor` field. The fields type is `MagickProgressMonitor` which is a type alias to a pointer of an implementation of a function. So all the image attributes could be equal but be false due to this field.

I thought I saw a bindgen issue for this, but can't find it now. Possible solutions might be to:
- Ask bindgen to not derive `PartialEq` -- there's a [no_partialeq function](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.no_partialeq) for that.
- Create a Rust wrapper struct which compares the correct fields & disconnects the API from the bindgen code.



