### PR TITLE
set_resource_limit ImageMagick API use correction

### DIFF
--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -80,11 +80,14 @@ impl MagickWand {
         }
     }
 
-    // opt-in platforms that have resource limits support
+    /// opt-in platforms that have resource limits support
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn set_resource_limit(resource: ResourceType, limit: u64) -> Result<()> {
         let result = unsafe {
-            bindings::SetMagickResourceLimit(resource, limit as bindings::MagickSizeType)
+            // Note: `MagickSetResourceLimit` wraps a call to `SetMagickResourceLimit`
+            // in ImageMagick, but preferring `MagickSetResourceLimit` as the call
+            // because `SetMagickResourceLimit` is not  in its published API documentation.
+            bindings::MagickSetResourceLimit(resource, limit as bindings::MagickSizeType)
         };
         match result {
             MagickTrue => Ok(()),
@@ -322,7 +325,7 @@ impl MagickWand {
         }
     }
 
-    // Replaces colors in the image from a color lookup table.
+    /// Replaces colors in the image from a color lookup table.
     pub fn clut_image(&self, clut_wand: &MagickWand, method: PixelInterpolateMethod) -> Result<()> {
         let result = unsafe { bindings::MagickClutImage(self.wand, clut_wand.wand, method) };
         match result {
@@ -358,15 +361,15 @@ impl MagickWand {
         }
     }
 
-    // Define two 'quantum_range' functions because the bindings::QuantumRange symbol
-    // is not available if hdri is disabled in the compiled ImageMagick libs
+    /// Define two 'quantum_range' functions because the bindings::QuantumRange symbol
+    /// is not available if hdri is disabled in the compiled ImageMagick libs
     #[cfg(not(feature = "disable-hdri"))]
     fn quantum_range(&self) -> Result<f64> {
         Ok(bindings::QuantumRange)
     }
 
-    // with disable-hdri enabled we define our own quantum_range
-    // values lifted directly from magick-type.h
+    /// with disable-hdri enabled we define our own quantum_range
+    /// values lifted directly from magick-type.h
     #[cfg(feature = "disable-hdri")]
     fn quantum_range(&self) -> Result<f64> {
         match bindings::MAGICKCORE_QUANTUM_DEPTH {
@@ -380,8 +383,8 @@ impl MagickWand {
         }
     }
 
-    // Level an image. Black and white points are multiplied with QuantumRange to
-    // decrease dependencies on the end user.
+    /// Level an image. Black and white points are multiplied with QuantumRange to
+    /// decrease dependencies on the end user.
     pub fn level_image(&self, black_point: f64, gamma: f64, white_point: f64) -> Result<()> {
         let quantum_range = self.quantum_range()?;
 
@@ -419,8 +422,8 @@ impl MagickWand {
         }
     }
 
-    //MagickNormalizeImage enhances the contrast of a color image by adjusting the pixels color
-    //to span the entire range of colors available
+    /// MagickNormalizeImage enhances the contrast of a color image by adjusting the pixels color
+    /// to span the entire range of colors available
     pub fn normalize_image(&self) -> Result<()> {
         let result = unsafe { bindings::MagickNormalizeImage(self.wand) };
         match result {
@@ -429,9 +432,9 @@ impl MagickWand {
         }
     }
 
-    //MagickOrderedDitherImage performs an ordered dither based on a number of pre-defined
-    //dithering threshold maps, but over multiple intensity levels, which can be different for
-    //different channels, according to the input arguments.
+    /// MagickOrderedDitherImage performs an ordered dither based on a number of pre-defined
+    /// dithering threshold maps, but over multiple intensity levels, which can be different for
+    /// different channels, according to the input arguments.
     pub fn ordered_dither_image(&self, threshold_map: &str) -> Result<()> {
         let c_threshold_map =
             CString::new(threshold_map).map_err(|_| "threshold_map string contains null byte")?;

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -84,9 +84,6 @@ impl MagickWand {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn set_resource_limit(resource: ResourceType, limit: u64) -> Result<()> {
         let result = unsafe {
-            // Note: `MagickSetResourceLimit` wraps a call to `SetMagickResourceLimit`
-            // in ImageMagick, but preferring `MagickSetResourceLimit` as the call
-            // because `SetMagickResourceLimit` is not  in its published API documentation.
             bindings::MagickSetResourceLimit(resource, limit as bindings::MagickSizeType)
         };
         match result {


### PR DESCRIPTION
Changes:
- Fixed some comments that were probably mean't to be fn docs
- Swaps a call to `SetMagickResourceLimit` with `MagickSetResourceLimit` -- explantion below.

**TL;DR**

- ImageCore API = ``SetMagickResourceLimit`
- ImageWand API = `MagickSetResourceLimit` 
- No functional change as the one calls the other in their codebase.

**Details**

I noticed `SetMagickResourceLimit` was not in ImageMagick's MagickWand API documentation, then found  `MagickSetResourceLimit` was in the API.

Looking at their source code, The `MagickSetResourceLimit` is in the `MagickWand/magick-property.h` ([here](https://github.com/ImageMagick/ImageMagick/blob/e16cb77ba0097fa6f3f702155c681c5ceb2e63c8/MagickWand/magick-property.h#L116)), and `SetMagickResourceLimit` is `MagickCore/resource_.h` ([here](https://github.com/ImageMagick/ImageMagick/blob/e16cb77ba0097fa6f3f702155c681c5ceb2e63c8/MagickCore/resource_.h#L51))

This PR swaps the call to `SetMagickResourceLimit` with `MagickSetResourceLimit` as they are used in `wand/magick.rs` which would be based on the MagickWand API.

Functionality-wise there's no change, as `MagickSetResourceLimit` just calls `SetMagickResourceLimit` in ImageMagick's [code](https://github.com/ImageMagick/ImageMagick/blob/e16cb77ba0097fa6f3f702155c681c5ceb2e63c8/MagickWand/magick-property.c#L2779).