### PR TITLE
Remove C pointers from the API

### DIFF
--- a/src/types/image.rs
+++ b/src/types/image.rs
@@ -23,7 +23,7 @@ pub struct Image<'a> {
 }
 
 impl Image<'_> {
-    pub fn new(img: *mut bindings::Image) -> Self {
+    pub (crate) fn new(img: *mut bindings::Image) -> Self {
         // SAFETY: This is safe and also does not require an Image::drop() call as:
         //         The lifetime of Image is the same as the lifetime of wrapped bindings::Image.
         //         The bindings::Image is borrowed by the caller from MagickWand.
@@ -35,7 +35,7 @@ impl Image<'_> {
         }
     }
 
-    pub unsafe fn get_ptr(&self) -> *mut bindings::Image {
+    pub (crate) unsafe fn get_ptr(&self) -> *mut bindings::Image {
         self.image
     }
 }

--- a/src/types/kernel.rs
+++ b/src/types/kernel.rs
@@ -244,7 +244,7 @@ impl KernelInfo {
         unsafe { bindings::UnityAddKernelInfo(self.kernel_info, scale) }
     }
 
-    pub unsafe fn get_ptr(&self) -> *mut bindings::KernelInfo {
+    pub (crate) unsafe fn get_ptr(&self) -> *mut bindings::KernelInfo {
         self.kernel_info
     }
 }

--- a/src/wand/macros.rs
+++ b/src/wand/macros.rs
@@ -19,7 +19,7 @@ macro_rules! wand_common {
         $clear_exc:ident, $get_exc_type:ident, $get_exc:ident
     ) => {
         pub struct $wand {
-            pub wand: *mut crate::bindings::$wand,
+            wand: *mut crate::bindings::$wand,
         }
 
         impl Default for $wand {
@@ -35,14 +35,14 @@ macro_rules! wand_common {
                 }
             }
 
-            pub fn new_from_wand(wand: *mut crate::bindings::$wand) -> Self {
-                $wand { wand }
-            }
-
-            fn from_ptr(ptr: *mut crate::bindings::$wand) -> Self {
+            pub (crate) fn from_ptr(ptr: *mut crate::bindings::$wand) -> Self {
                 $wand {
                     wand: ptr
                 }
+            }
+
+            pub (crate) fn as_ptr(&self) -> *mut crate::bindings::$wand {
+                self.wand
             }
 
             fn clear(&mut self) {
@@ -222,11 +222,11 @@ macro_rules! pixel_set_get {
         $(
             pub fn $get(&self) -> crate::PixelWand {
                 let pw = crate::PixelWand::new();
-                unsafe { crate::bindings::$c_get(self.wand, pw.wand) };
+                unsafe { crate::bindings::$c_get(self.wand, pw.as_ptr()) };
                 pw
             }
             pub fn $set(&mut self, pw: &crate::PixelWand) {
-                unsafe { crate::bindings::$c_set(self.wand, pw.wand) }
+                unsafe { crate::bindings::$c_set(self.wand, pw.as_ptr()) }
             }
         )*
         pub fn fmt_pixel_settings(&self, f: &mut ::std::fmt::Formatter, prefix: &str) -> ::std::fmt::Result {

--- a/src/wand/magick.rs
+++ b/src/wand/magick.rs
@@ -73,7 +73,7 @@ impl MagickWand {
 
     pub fn new_image(&self, columns: usize, rows: usize, background: &PixelWand) -> Result<()> {
         self.result_from_boolean(unsafe {
-            bindings::MagickNewImage(self.wand, columns, rows, background.wand)
+            bindings::MagickNewImage(self.wand, columns, rows, background.as_ptr())
         })
     }
 
@@ -108,7 +108,7 @@ impl MagickWand {
         self.result_from_boolean(unsafe {
             bindings::MagickAnnotateImage(
                 self.wand,
-                drawing_wand.wand,
+                drawing_wand.as_ptr(),
                 x,
                 y,
                 angle,
@@ -489,7 +489,7 @@ impl MagickWand {
     /// filling any empty space with the background color of a given PixelWand
     pub fn rotate_image(&self, background: &PixelWand, degrees: f64) -> Result<()> {
         self.result_from_boolean(unsafe {
-            bindings::MagickRotateImage(self.wand, background.wand, degrees)
+            bindings::MagickRotateImage(self.wand, background.as_ptr(), degrees)
         })
     }
 
@@ -649,7 +649,7 @@ impl MagickWand {
     pub fn get_image_pixel_color(&self, x: isize, y: isize) -> Option<PixelWand> {
         let pw = PixelWand::new();
 
-        let result = unsafe { bindings::MagickGetImagePixelColor(self.wand, x, y, pw.wand) };
+        let result = unsafe { bindings::MagickGetImagePixelColor(self.wand, x, y, pw.as_ptr()) };
         self.result_from_boolean(result).map(|_| pw).ok()
     }
 
@@ -676,7 +676,7 @@ impl MagickWand {
                 .map(|ptrs| {
                     slice::from_raw_parts(ptrs, color_count)
                         .iter()
-                        .map(|raw_wand| PixelWand { wand: *raw_wand })
+                        .map(|wand_ptr| PixelWand::from_ptr(*wand_ptr))
                         .collect()
                 })
         }
@@ -698,14 +698,14 @@ impl MagickWand {
     /// Set the background color.
     pub fn set_background_color(&self, pixel_wand: &PixelWand) -> Result<()> {
         self.result_from_boolean(unsafe {
-            bindings::MagickSetBackgroundColor(self.wand, pixel_wand.wand)
+            bindings::MagickSetBackgroundColor(self.wand, pixel_wand.as_ptr())
         })
     }
 
     /// Set the image background color.
     pub fn set_image_background_color(&self, pixel_wand: &PixelWand) -> Result<()> {
         self.result_from_boolean(unsafe {
-            bindings::MagickSetImageBackgroundColor(self.wand, pixel_wand.wand)
+            bindings::MagickSetImageBackgroundColor(self.wand, pixel_wand.as_ptr())
         })
     }
 
@@ -982,7 +982,7 @@ impl MagickWand {
 
     /// Renders the drawing wand on the current image
     pub fn draw_image(&mut self, drawing_wand: &DrawingWand) -> Result<()> {
-        self.result_from_boolean(unsafe { bindings::MagickDrawImage(self.wand, drawing_wand.wand) })
+        self.result_from_boolean(unsafe { bindings::MagickDrawImage(self.wand, drawing_wand.as_ptr()) })
     }
 
     /// Removes skew from the image. Skew is an artifact that
@@ -1026,7 +1026,7 @@ impl MagickWand {
         compose: CompositeOperator,
     ) -> Result<()> {
         self.result_from_boolean(unsafe {
-            bindings::MagickBorderImage(self.wand, pixel_wand.wand, width, height, compose)
+            bindings::MagickBorderImage(self.wand, pixel_wand.as_ptr(), width, height, compose)
         })
     }
 


### PR DESCRIPTION
## Proposal

Remove C pointers from the API.

**Resulting changes:**

- Functions that either accept or return pointers change from `pub` to `pub (crate)`
- A field that is a pointer from `pub` to private and the addition of a `pub (crate)` accessor function.

Internal usage across modules is maintained.

Tested on MacOS and in the Docker container.

## Reasoning

(I aplogise in advance if I'm over-explaining, but I felt I needed to fully justify an API change that shuts off part of the API and the possibility of intermixing the Rust and C API by a user.)

1. The returned pointers are only useful to a user so as to access the C API.  
2. Passing a pointer into the Rust API s only useful if they were created using the C API externally.

In either case, the pointer may become unexpectedly invalid from the users perspective either by this Rust library or the C library.

I'd suggest it isn't feasible to have them as `pub unsafe` and then up to the user to ensure correctness, as no pattern for correctness could be suggested to the user, as either the Rust or C libraries could change internally.

**Example**

An example of why it's too complicated to leave this:

**On the C side** a pointer to an `Image` can become invalid when calling one of these functions:
1. Directly using `DestroyImage`
2. Indirectly using `DestroyImageList`
3. Indirectly using `DestroyMagickMemory`

All these are needed as an `Image` can be created in many ways on the C API - e.g. by `CloneImage`. The API user is expected to know which to use, and can because they know how they obtained it. Given the pointer by the Rust API they won't.

**While on the Rust side**:

1. `MagicWand` ties the lifetime of `Image` to itself, so that Image cannot outlive `MagickWand`.
2. There is no `drop()` function in `Image` calling `bindings::DestroyImage` as it is not needed due to the above.
3. When `MagicWand` goes out of scope it calls `DestroyMagickMemory` which calls `DestroyImageList` which calls `DestroyImage`.

Hence mixing the 2 APIs isn't feasible (even as `unsafe`) as it is not apparent to the user how the pointer was obtained on the Rust side, nor if determining this by examining the source whether the internal implementation changes in the future. Passing in the pointer from C to Rust is equally hazardous as the Rust library can't know how the pointer was obtained either. 

## What reasonable usage could this prevent?

If there is a C API function that is not implemented by the Rust API, a user could obtain a pointer so as to use the C API directly, having created their own binding to the function they require. There is at least one Issue where a user did this.
However this would be a brittle implementation by the user as it's prone to error as already suggested, and underlying changes,

Alternative actions by a user would be to raise an Issue or create a PR.

## Note

I quite liked changing the `$wand:wand` field to private and replacing access with a function, as it seems nicer that the other wands can refer to their field directly but to other types of wand through the function, making which is which potentially clearer.
Obviously happy to change this if you prefer the `pub (crate)` field access.